### PR TITLE
Pass any missing parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Internals:
 
 ## Run for development
 
-Firs, install all dependencies and link packages
+First, install all dependencies and link packages
 
 ```
 npm i

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "setup": "npx lerna bootstrap",
     "build": "npx lerna run build",
     "test": "npx jest packages/*/test --verbose --coverage --collectCoverageFrom=packages/*/src/**/*",
+    "test:watch": "npx jest packages/*/test --watch",
     "lint": "npx eslint ./packages --ext .json,.js,.ts",
     "lint:fix": "npx eslint ./packages --ext .json,.js,.ts --fix"
   },

--- a/packages/rlogin-dcent-provider/package-lock.json
+++ b/packages/rlogin-dcent-provider/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "@rsksmart/rlogin-dcent-provider",
-	"version": "1.0.0",
+	"version": "1.0.2-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@rsksmart/rlogin-dcent-provider",
-			"version": "1.0.0",
+			"version": "1.0.2-beta.1",
 			"license": "MIT",
 			"dependencies": {
 				"@rsksmart/dcent-provider": "^0.3.0-beta",
+				"@rsksmart/rlogin-transactions": "^1.0.1",
 				"assert": "^2.0.0",
 				"buffer": "^6.0.3",
 				"stream-browserify": "^3.0.0",
@@ -382,6 +383,19 @@
 				"dcent-web-connector": "^0.10.0",
 				"web3-provider-engine": "^15.0.7"
 			}
+		},
+		"node_modules/@rsksmart/rlogin-transactions": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rsksmart/rlogin-transactions/-/rlogin-transactions-1.0.1.tgz",
+			"integrity": "sha512-4t1FZH6h2TnLfFbfhfY29ENmbTvg56PC6j7awYuWpiQUF/1tMUnrUJ9QX7IaTSJ2QX2QaHu4CuG811iaPRhR0A==",
+			"dependencies": {
+				"bn.js": "^5.2.0"
+			}
+		},
+		"node_modules/@rsksmart/rlogin-transactions/node_modules/bn.js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
 		},
 		"node_modules/@types/node": {
 			"version": "16.7.1",
@@ -3058,6 +3072,21 @@
 			"requires": {
 				"dcent-web-connector": "^0.10.0",
 				"web3-provider-engine": "^15.0.7"
+			}
+		},
+		"@rsksmart/rlogin-transactions": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rsksmart/rlogin-transactions/-/rlogin-transactions-1.0.1.tgz",
+			"integrity": "sha512-4t1FZH6h2TnLfFbfhfY29ENmbTvg56PC6j7awYuWpiQUF/1tMUnrUJ9QX7IaTSJ2QX2QaHu4CuG811iaPRhR0A==",
+			"requires": {
+				"bn.js": "^5.2.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+					"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+				}
 			}
 		},
 		"@types/node": {

--- a/packages/rlogin-dcent-provider/package.json
+++ b/packages/rlogin-dcent-provider/package.json
@@ -31,7 +31,7 @@
 		"@rsksmart/dcent-provider": "^0.3.0-beta",
 		"@rsksmart/rlogin-dpath": "^1.0.1",
 		"@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.1",
-		"@rsksmart/rlogin-transactions": "^1.0.1",
+		"@rsksmart/rlogin-transactions": "^1.0.2-beta.1",
 		"assert": "^2.0.0",
 		"buffer": "^6.0.3",
 		"stream-browserify": "^3.0.0",

--- a/packages/rlogin-dcent-provider/package.json
+++ b/packages/rlogin-dcent-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rsksmart/rlogin-dcent-provider",
-	"version": "1.0.1",
+	"version": "1.0.2-beta.1",
 	"description": "rLogin - D'cent EIP-1193 provider",
 	"main": "dist/bundle.js",
 	"types": "dist/index.d.ts",

--- a/packages/rlogin-ledger-provider/package.json
+++ b/packages/rlogin-ledger-provider/package.json
@@ -36,7 +36,7 @@
 		"@ledgerhq/hw-transport-webhid": "^6.4.1",
 		"@ledgerhq/hw-transport-webusb": "^6.3.0",
     "@rsksmart/rlogin-dpath": "^1.0.1",
-    "@rsksmart/rlogin-transactions": "^1.0.1",
+    "@rsksmart/rlogin-transactions": "^1.0.2-beta.1",
     "@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.1",
 		"assert": "^2.0.0",
 		"bn.js": "^5.2.0",

--- a/packages/rlogin-ledger-provider/package.json
+++ b/packages/rlogin-ledger-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rsksmart/rlogin-ledger-provider",
-	"version": "1.0.1",
+	"version": "1.0.2-beta.1",
 	"description": "rLogin - Ledger EIP-1193 provider",
 	"main": "dist/bundle.js",
 	"types": "dist/index.d.ts",

--- a/packages/rlogin-transactions/package.json
+++ b/packages/rlogin-transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin-transactions",
-  "version": "1.0.2",
+  "version": "1.0.2-beta.1",
   "description": "rLogin - transactions helper",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/packages/rlogin-transactions/package.json
+++ b/packages/rlogin-transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin-transactions",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "rLogin - transactions helper",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/packages/rlogin-transactions/src/index.ts
+++ b/packages/rlogin-transactions/src/index.ts
@@ -19,6 +19,7 @@ export type CompleteTx = {
  */
 export const createTransaction = async (provider: any, from: string, tx: Transaction): Promise<CompleteTx> => {
   const finalTx: Partial<CompleteTx> = {
+    ...tx,
     from: from.toLowerCase(),
     to: tx.to.toLowerCase(),
     nonce: tx.nonce || await provider.getTransactionCount(from).then(r => r.toNumber()),

--- a/packages/rlogin-transactions/test/index.test.ts
+++ b/packages/rlogin-transactions/test/index.test.ts
@@ -33,6 +33,7 @@ describe('createTransaction', () => {
       tx.from,
       {
         ...tx,
+        // @ts-ignore
         gas: 12000
       }
     )

--- a/packages/rlogin-transactions/test/index.test.ts
+++ b/packages/rlogin-transactions/test/index.test.ts
@@ -27,7 +27,7 @@ describe('createTransaction', () => {
     })
   })
 
-  test('can pass gas property' , async () => {
+  test('can pass gas property', async () => {
     const result = await createTransaction(
       provider,
       tx.from,

--- a/packages/rlogin-transactions/test/index.test.ts
+++ b/packages/rlogin-transactions/test/index.test.ts
@@ -1,5 +1,49 @@
-describe('test', () => {
-  test('test', () => {
-    expect(true).toBeTruthy()
+import { Transaction } from '@rsksmart/rlogin-eip1193-types'
+import { createTransaction } from '../src/index'
+import BN from 'bn.js'
+
+describe('createTransaction', () => {
+  const provider = {
+    getTransactionCount: () => Promise.resolve(new BN(5)),
+    gasPrice: () => Promise.resolve(new BN(10000)),
+    estimateGas: () => Promise.resolve(35000)
+  }
+
+  const tx: Transaction = {
+    to: '0x123456789',
+    from: '0x987654321',
+    value: '10000'
+  }
+
+  test('standard transaction', async () => {
+    const result = await createTransaction(provider, tx.from, tx)
+    expect(result).toMatchObject({
+      ...tx,
+      data: '0x0',
+      value: '0x2710',
+      gasLimit: 35000,
+      gasPrice: 10100,
+      nonce: 5
+    })
+  })
+
+  test('can pass gas property' , async () => {
+    const result = await createTransaction(
+      provider,
+      tx.from,
+      {
+        ...tx,
+        gas: 12000
+      }
+    )
+    expect(result).toMatchObject({
+      ...tx,
+      gas: 12000,
+      data: '0x0',
+      value: '0x2710',
+      gasLimit: 35000,
+      gasPrice: 10100,
+      nonce: 5
+    })
   })
 })

--- a/packages/rlogin-trezor-provider/package-lock.json
+++ b/packages/rlogin-trezor-provider/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "@rsksmart/rlogin-trezor-provider",
-	"version": "1.0.0",
+	"version": "1.0.2-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@rsksmart/rlogin-trezor-provider",
-			"version": "1.0.0",
+			"version": "1.0.2-beta.1",
 			"license": "MIT",
 			"dependencies": {
 				"@ethereumjs/tx": "^3.3.0",
+				"@rsksmart/rlogin-transactions": "^1.0.1",
 				"assert": "^2.0.0",
 				"buffer": "^6.0.3",
 				"ethjs-provider-http": "^0.1.6",
@@ -49,6 +50,14 @@
 			"dependencies": {
 				"@ethereumjs/common": "^2.4.0",
 				"ethereumjs-util": "^7.1.0"
+			}
+		},
+		"node_modules/@rsksmart/rlogin-transactions": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rsksmart/rlogin-transactions/-/rlogin-transactions-1.0.1.tgz",
+			"integrity": "sha512-4t1FZH6h2TnLfFbfhfY29ENmbTvg56PC6j7awYuWpiQUF/1tMUnrUJ9QX7IaTSJ2QX2QaHu4CuG811iaPRhR0A==",
+			"dependencies": {
+				"bn.js": "^5.2.0"
 			}
 		},
 		"node_modules/@types/bn.js": {
@@ -1038,6 +1047,14 @@
 			"requires": {
 				"@ethereumjs/common": "^2.4.0",
 				"ethereumjs-util": "^7.1.0"
+			}
+		},
+		"@rsksmart/rlogin-transactions": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rsksmart/rlogin-transactions/-/rlogin-transactions-1.0.1.tgz",
+			"integrity": "sha512-4t1FZH6h2TnLfFbfhfY29ENmbTvg56PC6j7awYuWpiQUF/1tMUnrUJ9QX7IaTSJ2QX2QaHu4CuG811iaPRhR0A==",
+			"requires": {
+				"bn.js": "^5.2.0"
 			}
 		},
 		"@types/bn.js": {

--- a/packages/rlogin-trezor-provider/package.json
+++ b/packages/rlogin-trezor-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rsksmart/rlogin-trezor-provider",
-	"version": "1.0.1",
+	"version": "1.0.2-beta.1",
 	"description": "rLogin - Trezor EIP-1193 provider",
 	"main": "dist/bundle.js",
 	"types": "dist/index.d.ts",

--- a/packages/rlogin-trezor-provider/package.json
+++ b/packages/rlogin-trezor-provider/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
     "@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.1",
-    "@rsksmart/rlogin-transactions": "^1.0.1",
+    "@rsksmart/rlogin-transactions": "^1.0.2-beta.1",
     "@rsksmart/rlogin-dpath": "^1.0.1",
 		"@ethereumjs/tx": "^3.3.0",
     "assert": "^2.0.0",


### PR DESCRIPTION
This PR changes `createTransaction` to pass any missing parameters not included in the Transaction object. This was brought up as the property `gas` was being passed to Ledger.

## what is done:

- passes any extra parameters to the provider
- adds two tests, one for standard and one for passing `gas`. More tests should be added in the future to test the other operations.




