### PR TITLE
Fix Dcent hardware wallet personalSign

### DIFF
--- a/packages/rlogin-dcent-provider/package.json
+++ b/packages/rlogin-dcent-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rsksmart/rlogin-dcent-provider",
-	"version": "1.0.2-beta.5",
+	"version": "1.0.2-beta.6",
 	"description": "rLogin - D'cent EIP-1193 provider",
 	"main": "dist/bundle.js",
 	"types": "dist/index.d.ts",

--- a/packages/rlogin-dcent-provider/src/DCentProvider.ts
+++ b/packages/rlogin-dcent-provider/src/DCentProvider.ts
@@ -70,10 +70,16 @@ export class DCentProvider extends RLoginEIP1193Provider {
   async personalSign (params: PersonalSignParams): Promise<string> {
     this.#validateIsConnected()
     this.#logger('🦄 attempting to sign message!')
-    const messageHex = Buffer.from(params[0]).toString('hex')
+
+    // convert the string to a hex if it isn't already:
+    const messageHex =
+      params[0].match(/^0x[0-9a-f]+$/i)
+        ? params[0]
+        : `0x${Buffer.from(params[0]).toString('hex')}`
+
     return await this.dcentProvider.send(
       'personal_sign',
-      [`0x${messageHex}`, params[1]]
+      [messageHex, params[1]]
     )
   }
 


### PR DESCRIPTION
D'Cent wallet expects the string coming in to be a hex value and it was assumed the value was a pure string. In the research with Ethers.js and Web3.js those libraries were converting it to hex before sending it to the provider so the previous implementation would "double hex it". This was incorrect.

This fix checks if the value is a hex value and if not converts it. 

This will resolve #60 and resolve https://github.com/rsksmart/rLogin/issues/284